### PR TITLE
Replace time.clock() with time.time() and add test

### DIFF
--- a/ratelimit/__init__.py
+++ b/ratelimit/__init__.py
@@ -1,5 +1,4 @@
 from math import floor
-
 import time
 import sys
 
@@ -25,12 +24,12 @@ def rate_limited(period = 1, every = 1.0):
     last_called = [0.0]
 
     def wrapper(*args, **kargs):
-      elapsed = time.clock() - last_called[0]
+      elapsed = time.time() - last_called[0]
       left_to_wait = frequency - elapsed
       if left_to_wait > 0:
         time.sleep(left_to_wait)
       ret = func(*args, **kargs)
-      last_called[0] = time.clock()
+      last_called[0] = time.time()
       return ret
     return wrapper
   return decorator

--- a/tests/unit/decorator_test.py
+++ b/tests/unit/decorator_test.py
@@ -1,3 +1,4 @@
+import time
 from ratelimit import rate_limited
 from tests import *
 
@@ -18,3 +19,11 @@ class TestDecorator(unittest.TestCase):
     self.assertEqual(self.count, 0)
     self.increment()
     self.assertEqual(self.count, 1)
+
+  def test_timing(self):
+    for i in range(10):
+      before = time.time()
+      self.increment()
+      after = time.time()
+      # allow a 0.1 second error
+      self.assertTrue((after-before - 2.0) < 0.1, "Function was executed too fast")


### PR DESCRIPTION
`time.clock()` should not be used since it relies on the CPU cycles, as in, it can sometimes go faster or slower than the actual time. Furthermore, it is also deprecated since Python 3.3.

Other than that it's a great little tool!