### PR TITLE
Shimon/ratelimit/add condition to rate limiter

### DIFF
--- a/tests/unit/decorator_test.py
+++ b/tests/unit/decorator_test.py
@@ -10,6 +10,14 @@ class TestDecorator(unittest.TestCase):
         '''
         self.count += 1
 
+    @limits(calls=1, period=10, clock=clock, raise_on_limit=False)
+    def increment_no_exception(self):
+        '''
+        Increment the counter at most once every 10 seconds, but w/o rasing
+        an exception when reaching limit.
+        '''
+        self.count += 1
+
     def setUp(self):
         self.count = 0
         clock.increment(10)
@@ -28,3 +36,7 @@ class TestDecorator(unittest.TestCase):
 
         self.increment()
         self.assertEqual(self.count, 2)
+
+    def test_no_exception(self):
+        self.increment_no_exception()
+        self.increment_no_exception()


### PR DESCRIPTION
This PR include additions below:
1. Adding a condition to RateLimitDecorator that will allow 'bypassing' limit, in exceptional cases.
2. Unit test for conditional ratelimiter.
3. Add the ability to avoid rasing an exception in case limit was reached, but also, avoid calling the function.

