### PR TITLE
Fix sleep_and_retry in case time.sleep returned early.

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -108,9 +108,9 @@ def sleep_and_retry(func):
         :param args: non-keyword variable length argument list to the decorated function.
         :param kargs: keyworded variable length argument list to the decorated function.
         '''
-        try:
-            return func(*args, **kargs)
-        except RateLimitException as exception:
-            time.sleep(exception.period_remaining)
-            return func(*args, **kargs)
+        while True:
+            try:
+                return func(*args, **kargs)
+            except RateLimitException as exception:
+                time.sleep(exception.period_remaining)
     return wrapper


### PR DESCRIPTION
This PR fixes https://github.com/tomasbasham/ratelimit/issues/19.
This bug can happen even using a single thread since time.sleep [might return early](https://stackoverflow.com/a/15967564).