### PR TITLE
Add reset_ratelimit method.

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -101,6 +101,7 @@ class RateLimitDecorator(object):
         Reset the ratelimit.
         '''
         self.last_reset = self.clock()
+        self.num_calls = 0
 
 def sleep_and_retry(func):
     '''

--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -83,6 +83,7 @@ class RateLimitDecorator(object):
                     return
 
             return func(*args, **kargs)
+        wrapper.reset_ratelimit = self.reset_ratelimit
         return wrapper
 
     def __period_remaining(self):
@@ -94,6 +95,12 @@ class RateLimitDecorator(object):
         '''
         elapsed = self.clock() - self.last_reset
         return self.period - elapsed
+    
+    def reset_ratelimit(self):
+        '''
+        Reset the ratelimit.
+        '''
+        self.last_reset = self.clock()
 
 def sleep_and_retry(func):
     '''


### PR DESCRIPTION
This adds a method `reset_ratelimit` which can be called at the beginning of a test and give the user some control over the ratelimit.

During unit testing I needed to reset limits as I go.

While I can use freezegun and faketime to change date / duration, you still need a way to reset the limit so the test can run in a predictable manner.
