### PR TITLE
Jordan/improve algorithm and add soft limit

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -25,8 +25,8 @@ class RateLimitDecorator(object):
             period=900,
             clock=now(),
             raise_on_limit=True,
-            treshold=None,
-            treshold_method=None
+            threshold=None,
+            threshold_method=None
     ):
         '''
         Instantiate a RateLimitDecorator with some sensible defaults. By
@@ -37,15 +37,15 @@ class RateLimitDecorator(object):
         :param float period: An upper bound time period (in seconds) before the rate limit resets.
         :param function clock: An optional function retuning the current time.
         :param bool raise_on_limit: A boolean allowing the caller to avoiding rasing an exception.
-        :param float treshold: Optional fraction of the maximum number of available requests
+        :param float threshold: Optional fraction of the maximum number of available requests
          under which calls invoke method, e.g: 0.2 to trigger at 20% remaining requests.
-        :param function treshold_method: An optional method to invoke when hitting the treshold.
+        :param function threshold_method: An optional method to invoke when hitting the threshold.
         '''
         self.clamped_calls = max(1, min(sys.maxsize, floor(calls)))
         self.period = period
         self.raise_on_limit = raise_on_limit
-        self.treshold = treshold
-        self.treshold_method = treshold_method
+        self.threshold = threshold
+        self.threshold_method = threshold_method
         self.clock = clock
 
         # Initialise the decorator state.
@@ -87,10 +87,10 @@ class RateLimitDecorator(object):
                 if self.allowance > self.clamped_calls:
                     self.allowance = self.clamped_calls
 
-                if self.treshold is not None and self.treshold_method is not None:
-                    treshold_allowance = self.treshold * self.clamped_calls
-                    if self.allowance < treshold_allowance:
-                        self.treshold_method()
+                if self.threshold is not None and self.threshold_method is not None:
+                    threshold_allowance = self.threshold * self.clamped_calls
+                    if self.allowance < threshold_allowance:
+                        self.threshold_method()
                 if self.allowance < 1.0:
                     period_renaming = self.__period_remaining()
                     if self.raise_on_limit:

--- a/tests/unit/decorator_test.py
+++ b/tests/unit/decorator_test.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock
 from ratelimit import limits, RateLimitException
 from tests import unittest, clock
 
+
 class TestDecorator(unittest.TestCase):
+    treshold_method = MagicMock()
 
     @limits(calls=1, period=10, clock=clock)
     def increment(self):
@@ -13,12 +16,43 @@ class TestDecorator(unittest.TestCase):
     @limits(calls=1, period=10, clock=clock, raise_on_limit=False)
     def increment_no_exception(self):
         '''
-        Increment the counter at most once every 10 seconds, but w/o rasing an
-        exception when reaching limit.
+        Increment the counter at most once every 10 seconds, without raising an exception when
+        reaching the rate limit.
+        '''
+        self.count += 1
+
+    @limits(
+        calls=1,
+        period=10,
+        clock=clock,
+        raise_on_limit=False,
+        treshold=0.5,
+        treshold_method=treshold_method
+    )
+    def increment_treshold_no_exception(self):
+        '''
+        Increment the counter at most once every 10 seconds, invoking the treshold method when
+        the treshold is reached, without raising an exception when reaching the rate limit.
+        '''
+        self.count += 1
+
+    @limits(
+        calls=4,
+        period=10,
+        clock=clock,
+        raise_on_limit=True,
+        treshold=0.5,
+        treshold_method=treshold_method
+    )
+    def increment_treshold(self):
+        '''
+        Increment the counter at most once every 10 seconds, triggering the treshold method when
+        the treshold is reached, while raising an exception when reaching the rate limit.
         '''
         self.count += 1
 
     def setUp(self):
+        self.treshold_method.reset_mock()
         self.count = 0
         clock.increment(10)
 
@@ -42,3 +76,29 @@ class TestDecorator(unittest.TestCase):
         self.increment_no_exception()
 
         self.assertEqual(self.count, 1)
+
+    def test_treshold_no_exception(self):
+        self.increment_treshold_no_exception()
+        self.increment_treshold_no_exception()
+        self.treshold_method.assert_called_once()
+
+    def test_treshold(self):
+        # These first 3 calls should not trigger the treshold method nor hit the rate limit
+        self.increment_treshold()
+        self.treshold_method.assert_not_called()
+
+        self.increment_treshold()
+        self.treshold_method.assert_not_called()
+
+        self.increment_treshold()
+        self.treshold_method.assert_not_called()
+
+        # This call causes the allowance to drop under the treshold, triggering the treshold_method
+        self.increment_treshold()
+        self.treshold_method.assert_called_once()
+
+        # This call is made while the allowance is still under the treshold value, triggering the
+        # treshold_method once more while also blocking the request as the rate limit has been hit
+        self.treshold_method.reset_mock()
+        self.assertRaises(RateLimitException, self.increment_treshold)
+        self.treshold_method.assert_called_once()

--- a/tests/unit/decorator_test.py
+++ b/tests/unit/decorator_test.py
@@ -4,7 +4,7 @@ from tests import unittest, clock
 
 
 class TestDecorator(unittest.TestCase):
-    treshold_method = MagicMock()
+    threshold_method = MagicMock()
 
     @limits(calls=1, period=10, clock=clock)
     def increment(self):
@@ -26,13 +26,13 @@ class TestDecorator(unittest.TestCase):
         period=10,
         clock=clock,
         raise_on_limit=False,
-        treshold=0.5,
-        treshold_method=treshold_method
+        threshold=0.5,
+        threshold_method=threshold_method
     )
-    def increment_treshold_no_exception(self):
+    def increment_threshold_no_exception(self):
         '''
-        Increment the counter at most once every 10 seconds, invoking the treshold method when
-        the treshold is reached, without raising an exception when reaching the rate limit.
+        Increment the counter at most once every 10 seconds, invoking the threshold method when
+        the threshold is reached, without raising an exception when reaching the rate limit.
         '''
         self.count += 1
 
@@ -41,18 +41,18 @@ class TestDecorator(unittest.TestCase):
         period=10,
         clock=clock,
         raise_on_limit=True,
-        treshold=0.5,
-        treshold_method=treshold_method
+        threshold=0.5,
+        threshold_method=threshold_method
     )
-    def increment_treshold(self):
+    def increment_threshold(self):
         '''
-        Increment the counter at most once every 10 seconds, triggering the treshold method when
-        the treshold is reached, while raising an exception when reaching the rate limit.
+        Increment the counter at most once every 10 seconds, triggering the threshold method when
+        the threshold is reached, while raising an exception when reaching the rate limit.
         '''
         self.count += 1
 
     def setUp(self):
-        self.treshold_method.reset_mock()
+        self.threshold_method.reset_mock()
         self.count = 0
         clock.increment(10)
 
@@ -77,28 +77,28 @@ class TestDecorator(unittest.TestCase):
 
         self.assertEqual(self.count, 1)
 
-    def test_treshold_no_exception(self):
-        self.increment_treshold_no_exception()
-        self.increment_treshold_no_exception()
-        self.treshold_method.assert_called_once()
+    def test_threshold_no_exception(self):
+        self.increment_threshold_no_exception()
+        self.increment_threshold_no_exception()
+        self.threshold_method.assert_called_once()
 
-    def test_treshold(self):
-        # These first 3 calls should not trigger the treshold method nor hit the rate limit
-        self.increment_treshold()
-        self.treshold_method.assert_not_called()
+    def test_threshold(self):
+        # These first 3 calls should not trigger the threshold method nor hit the rate limit
+        self.increment_threshold()
+        self.threshold_method.assert_not_called()
 
-        self.increment_treshold()
-        self.treshold_method.assert_not_called()
+        self.increment_threshold()
+        self.threshold_method.assert_not_called()
 
-        self.increment_treshold()
-        self.treshold_method.assert_not_called()
+        self.increment_threshold()
+        self.threshold_method.assert_not_called()
 
-        # This call causes the allowance to drop under the treshold, triggering the treshold_method
-        self.increment_treshold()
-        self.treshold_method.assert_called_once()
+        # This call causes the allowance to drop under the threshold, triggering the threshold_method
+        self.increment_threshold()
+        self.threshold_method.assert_called_once()
 
-        # This call is made while the allowance is still under the treshold value, triggering the
-        # treshold_method once more while also blocking the request as the rate limit has been hit
-        self.treshold_method.reset_mock()
-        self.assertRaises(RateLimitException, self.increment_treshold)
-        self.treshold_method.assert_called_once()
+        # This call is made while the allowance is still under the threshold value, triggering the
+        # threshold_method once more while also blocking the request as the rate limit has been hit
+        self.threshold_method.reset_mock()
+        self.assertRaises(RateLimitException, self.increment_threshold)
+        self.threshold_method.assert_called_once()


### PR DESCRIPTION
This PR contains an improved rate limiting algorithm, as well as a soft limit feature.

The rate limiting algorithm replacing the fixed time windows with a token bucket approach instead, ensuring that no more endpoint requests than the imposed limit can happen in the given period (improving the current implementation, where twice the allowed number of requests is permitted (if the first half happened during the end of one time window, while the second half requesting at the start of the next time window).

The soft limiting feature provides the possibility to generate f.e. a warning when a rate-limited endpoint is close to hitting that limit. This can be used to act upon, before the endpoint has actually hit the rate limit and starts blocking new requests. This soft limiting is configured using two parameters: `treshold`, which is the fraction of remaining requests under which to trigger provided `treshold_method` (e.g. `threshold=0.2` for triggering on requests with less than 20% remaining requests)