### PR TITLE
changing default value of call

### DIFF
--- a/ratelimit/decorators.py
+++ b/ratelimit/decorators.py
@@ -19,7 +19,7 @@ class RateLimitDecorator(object):
     '''
     Rate limit decorator class.
     '''
-    def __init__(self, calls=15, period=900, clock=now(), raise_on_limit=True):
+    def __init__(self, calls=15, period=900, clock=now, raise_on_limit=True):
         '''
         Instantiate a RateLimitDecorator with some sensible defaults. By
         default the Twitter rate limiting window is respected (15 calls every


### PR DESCRIPTION
the default value should be a callable function like time.time  not a value 
```
def __init__(self, calls=15, period=900, clock=now, raise_on_limit=True):
```